### PR TITLE
Fixed 2D template rotation

### DIFF
--- a/coast_guard/cleaners/surgical.py
+++ b/coast_guard/cleaners/surgical.py
@@ -154,7 +154,13 @@ class SurgicalScrubCleaner(cleaners.BaseCleaner):
 
         print('Calculating robust statistics to determine where RFI removal is required')
         # consider residual only in off-pulse region
-        template_rot = clean_utils.fft_rotate(template, phs).squeeze()
+
+        if template.ndim > 1:
+            # assuming the channel axis is 0, rotate each channel profile
+            template_rot = np.apply_along_axis(clean_utils.fft_rotate, 0, template, phs).squeeze()
+        else:
+            template_rot = clean_utils.fft_rotate(tempalte, phs).squeeze()
+        
         masked_template = np.ma.masked_greater(template_rot, np.min(template_rot) + 0.03*np.ptp(template_rot))
         if len(np.shape(template_rot)) > 1:
             # template is 2D

--- a/coast_guard/cleaners/surgical.py
+++ b/coast_guard/cleaners/surgical.py
@@ -130,9 +130,9 @@ class SurgicalScrubCleaner(cleaners.BaseCleaner):
             print('Template phase offset = {0}'.format(round(phs, 3)))
 
         print('Removing profile from patient')
-        preop_patient = patient.clone()
-        preop_patient.remove_baseline()
-        preop_weights = preop_patient.get_weights()
+        #preop_patient = patient.clone()
+        #preop_patient.remove_baseline()
+        #preop_weights = preop_patient.get_weights()
         #print(preop_weights.shape)
 
         clean_utils.remove_profile_inplace(patient, template, phs)


### PR DESCRIPTION
Template rotation `fft_rotate` in `clean_utils` operates on the assumption that the input array is 1D, so to rotate the 2D template we need to apply that function over the frequency channel axis.